### PR TITLE
feat: Enable 3D controls by default and change cursor on cube hover

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    '@babel/preset-env',
+    ['@babel/preset-react', {runtime: 'automatic'}],
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"start": "webpack-dev-server .",
 		"build": "Webpack .",
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "jest"
 	},
 	"keywords": [],
 	"author": "",
@@ -25,16 +25,31 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.23.6",
-		"@babel/preset-env": "^7.23.6",
-		"@babel/preset-react": "^7.23.3",
+		"@babel/preset-env": "^7.27.2",
+		"@babel/preset-react": "^7.27.1",
 		"@svgr/webpack": "^8.1.0",
+		"@testing-library/jest-dom": "^6.6.3",
+		"@testing-library/react": "^16.3.0",
+		"@testing-library/user-event": "^14.6.1",
 		"babel-loader": "^9.1.3",
 		"css-loader": "^6.8.1",
 		"file-loader": "^6.2.0",
 		"html-webpack-plugin": "^5.6.0",
+		"identity-obj-proxy": "^3.0.0",
+		"jest": "^29.7.0",
+		"jest-environment-jsdom": "^29.7.0",
 		"style-loader": "^3.3.3",
 		"webpack": "^5.89.0",
 		"webpack-cli": "^5.1.4",
 		"webpack-dev-server": "^4.15.1"
+	},
+	"jest": {
+		"moduleNameMapper": {
+			"\\.(css|less|scss|sass)$": "identity-obj-proxy"
+		},
+		"testEnvironment": "jsdom",
+		"setupFilesAfterEnv": [
+			"<rootDir>/src/setupTests.js"
+		]
 	}
 }

--- a/src/components/CubeWithControls/CubeWithControls.test.js
+++ b/src/components/CubeWithControls/CubeWithControls.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CubeWithControls from './index'; // Assuming the component is exported from index.js
+
+// Mock child components that are not relevant to this test or might cause issues during rendering.
+jest.mock('../../components/common/Cube', () => () => <div data-testid="mock-cube" />);
+jest.mock('../../components/common/ThreeCanvas', () => (props) => (
+  <div data-testid="mock-three-canvas" data-orbitcontrol={props.orbitControl}>
+    {props.component}
+  </div>
+));
+jest.mock('../common/DirectionControl', () => () => <div data-testid="mock-direction-control" />);
+jest.mock('../common/ZoomControl', () => () => <div data-testid="mock-zoom-control" />);
+// Icon3d is the component we are testing the state of, so we don't mock it.
+// jest.mock('../common/Icon3d', () => ({ onClickEvent, stateValue, title, disableTitle, placement }) => (
+//   <div title={stateValue ? disableTitle : title} data-testid="mock-icon3d" />
+// ));
+jest.mock('../common/Icon360', () => ({ onClickEvent, stateValue, title, disableTitle, placement }) => (
+    <div title={stateValue ? disableTitle : title} data-testid="mock-icon360" />
+));
+jest.mock('../common/MultiDirectionalArrow', () => ({ onClickEvent, stateValue, title, disableTitle, placement }) => (
+    <div title={stateValue ? disableTitle : title} data-testid="mock-multidirectional-arrow" />
+));
+
+
+describe('CubeWithControls', () => {
+  test('should have 3D orbit controls enabled by default', () => {
+    render(<CubeWithControls dimensions={{ width: 1, height: 1, length: 1 }} />);
+    // The Icon3d component uses a Tooltip whose title changes based on the orbitControlToggle state.
+    // When true (enabled), the title is "Disable 3D control".
+    // We need to wait for the tooltip to appear if it's async.
+    // However, Material UI Tooltips are often rendered immediately with their title.
+    // The Icon3d (ThreeDRotationIcon) has the title as an aria-label on the SVG itself.
+    const icon3dElement = screen.getByLabelText(/disable 3d control/i);
+    expect(icon3dElement).toBeInTheDocument();
+  });
+});

--- a/src/components/CubeWithControls/index.js
+++ b/src/components/CubeWithControls/index.js
@@ -11,7 +11,7 @@ import MultiDirectionalArrow from "../common/MultiDirectionalArrow";
 const CubeWithControls = ({ dimensions }) => {
 	const cubeRef = useRef();
 	const [animateToggle, setAnimateToggle] = useState(false);
-	const [orbitControlToggle, setOrbitControlToggle] = useState(false);
+	const [orbitControlToggle, setOrbitControlToggle] = useState(true);
 	const [directionControlToggle, setDirectionControlToggle] = useState(false);
 	const [zoom, setZoom] = useState(1);
 

--- a/src/components/common/Cube/Cube.test.js
+++ b/src/components/common/Cube/Cube.test.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Cube from './index'; // Assuming the component is exported from index.js
+import { useFrame } from '@react-three/fiber';
+
+// Mock useFrame from @react-three/fiber as it's not relevant to this test
+// and might cause issues if not handled.
+jest.mock('@react-three/fiber', () => ({
+  ...jest.requireActual('@react-three/fiber'), // Import and retain default exports
+  useFrame: jest.fn(), // Mock useFrame specifically
+}));
+
+describe('Cube Component', () => {
+  let mockCubeRefObject; // This object will be passed as the ref prop
+
+  beforeEach(() => {
+    // Initialize the .current property of the ref object before each test.
+    // This represents the Three.js mesh-like object.
+    mockCubeRefObject = {
+      current: {
+        rotation: { y: 0 },
+        scale: { set: jest.fn() },
+      },
+    };
+    // Ensure a consistent starting state for cursor
+    document.body.style.cursor = 'auto';
+    useFrame.mockClear(); // Clear useFrame mock calls from previous tests
+  });
+
+  afterEach(() => {
+    // Reset cursor after each test to avoid side effects
+    document.body.style.cursor = 'auto';
+    // Clear mocks on the .current object if it and its methods exist
+    if (mockCubeRefObject.current && mockCubeRefObject.current.scale && mockCubeRefObject.current.scale.set) {
+        mockCubeRefObject.current.scale.set.mockClear();
+    }
+    // It's also good practice to reset the .current to a known state if needed,
+    // but beforeEach handles re-initialization.
+    useFrame.mockClear();
+  });
+
+  test('should change cursor to pointer on mouse over and back to auto on mouse out', () => {
+    // For this test, the internal state of mockCubeRefObject.current doesn't matter
+    // as much as React assigning the DOM element to it, which is fine.
+    render(
+      <Cube
+        width={1}
+        height={1}
+        length={1}
+        cubeRef={mockCubeRefObject}
+        animate={false}
+        zoom={1}
+      />
+    );
+
+    const meshElement = screen.getByTestId('cube-mesh');
+    // After render, React sets mockCubeRefObject.current to the DOM element.
+    // This is fine for this test as we are testing DOM event handlers.
+
+    expect(document.body.style.cursor).toBe('auto'); // Check initial state
+
+    fireEvent.pointerOver(meshElement);
+    expect(document.body.style.cursor).toBe('pointer');
+
+    fireEvent.pointerOut(meshElement);
+    expect(document.body.style.cursor).toBe('auto');
+  });
+
+  test('should call useFrame and update scale', () => {
+    const zoomLevel = 2;
+    // This render will call useFrame(callback) and set mockCubeRefObject.current = DOM element
+    render(
+      <Cube
+        width={1}
+        height={1}
+        length={1}
+        cubeRef={mockCubeRefObject}
+        animate={false}
+        zoom={zoomLevel}
+      />
+    );
+
+    expect(useFrame).toHaveBeenCalled(); // Check if useFrame was called
+
+    // Manually restore mockCubeRefObject.current to the shape expected by the useFrame callback
+    // This is because React's <mesh ref={mockCubeRefObject} /> would have set .current to the DOM element.
+    const scaleSetMock = jest.fn();
+    mockCubeRefObject.current = {
+      rotation: { y: 0 }, // Provide a default rotation object
+      scale: { set: scaleSetMock },
+    };
+
+    if (useFrame.mock.calls.length > 0) {
+      const frameCallback = useFrame.mock.calls[useFrame.mock.calls.length - 1][0]; // Get the latest callback
+      frameCallback(); // Execute the useFrame callback
+    }
+    expect(scaleSetMock).toHaveBeenCalledWith(zoomLevel, zoomLevel, zoomLevel);
+  });
+
+  test('should update rotation if animate is true', () => {
+    const initialRotationY = 0.5; // Arbitrary starting rotation
+    // This render will call useFrame(callback) and set mockCubeRefObject.current = DOM element
+    render(
+      <Cube
+        width={1}
+        height={1}
+        length={1}
+        cubeRef={mockCubeRefObject}
+        animate={true}
+        zoom={1}
+      />
+    );
+
+    expect(useFrame).toHaveBeenCalled();
+
+    // Manually restore mockCubeRefObject.current for the test
+    const scaleSetMock = jest.fn();
+    mockCubeRefObject.current = {
+      rotation: { y: initialRotationY },
+      scale: { set: scaleSetMock },
+    };
+
+    if (useFrame.mock.calls.length > 0) {
+      const frameCallback = useFrame.mock.calls[useFrame.mock.calls.length - 1][0];
+      frameCallback(); // Execute the useFrame callback
+    }
+    expect(mockCubeRefObject.current.rotation.y).toBeCloseTo(initialRotationY + 0.01);
+    expect(scaleSetMock).toHaveBeenCalledWith(1, 1, 1); // Also verify scale update
+  });
+});

--- a/src/components/common/Cube/index.js
+++ b/src/components/common/Cube/index.js
@@ -14,7 +14,10 @@ const Cube = ({ width, height, length, color, position, animate, cubeRef, zoom }
 	return (
 		<mesh
 			ref={cubeRef}
-			position={position || [0, 0, 0]}>
+			position={position || [0, 0, 0]}
+			onPointerOver={() => (document.body.style.cursor = "pointer")}
+			onPointerOut={() => (document.body.style.cursor = "auto")}
+			data-testid="cube-mesh">
 			<lineSegments>
 				<edgesGeometry
 					attach='geometry'

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom';


### PR DESCRIPTION
This commit introduces two main enhancements:

1.  Default 3D Orbit Controls: The 3D orbit controls are now enabled by default when the `CubeWithControls` component loads. This provides a more intuitive initial experience for you, allowing you to immediately interact with the cube using your mouse.
    - Modified `CubeWithControls/index.js` to set the initial state of `orbitControlToggle` to `true`.
    - Added a check in `CubeWithControls.test.js` to verify that the controls are enabled by default by checking the tooltip title of the control icon.
    - Set up the Jest testing environment including necessary babel configurations, `setupTests.js`, and `package.json` updates.

2.  Cursor Change on Cube Hover: The mouse cursor now changes to a 'pointer' (hand icon) when hovering over the 3D cube, providing a clear visual cue that the cube is interactive.
    - Modified `Cube/index.js` to add `onPointerOver` and `onPointerOut` event handlers to the cube's mesh, which update `document.body.style.cursor`.
    - Added `data-testid="cube-mesh"` to the cube's mesh for easier test querying.
    - Added checks in `Cube.test.js` to verify the cursor change on `pointerover` and `pointerout` events.
    - Included checks for the `useFrame` hook logic in `Cube.test.js`, ensuring scale and animation updates function as expected.